### PR TITLE
Bugfix AssetService with Google Storage

### DIFF
--- a/src/Core/Framework/Plugin/Util/AssetService.php
+++ b/src/Core/Framework/Plugin/Util/AssetService.php
@@ -57,7 +57,10 @@ class AssetService
         }
 
         $targetDirectory = $this->getTargetDirectory($bundle);
-        $this->filesystem->deleteDir($targetDirectory);
+        try {
+            $this->filesystem->deleteDir($targetDirectory);
+        } catch (\Google\Cloud\Core\Exception\NotFoundException $exception) {
+        }
 
         $this->copy($originDir, $targetDirectory);
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
The `Shopware\Core\Framework\Plugin\Util\AssetService` throws an exception `Google\Cloud\Core\Exception\NotFoundException` if Google Storage Adapter is in use and `$targetDirectory` doesn't exist in the cloud:

```
www-data@70b059319123:~/html$ bin/console assets:install -vvv
Copying files for bundle: FrameworkBundle
Copying files for bundle: MonologBundle
Copying files for bundle: SwiftmailerBundle
Copying files for bundle: SensioFrameworkExtraBundle
Copying files for bundle: TwigBundle
Copying files for bundle: WebProfilerBundle
Copying files for bundle: DebugBundle
Copying files for bundle: EnqueueBundle
Copying files for bundle: EnqueueAdapterBundle
Copying files for bundle: Framework
Copying files for bundle: System
Copying files for bundle: Content
Copying files for bundle: Checkout
Copying files for bundle: Profiling
Copying files for bundle: Administration
Copying files for bundle: Storefront

In RequestWrapper.php line 368:
                                                                                                      
  [Google\Cloud\Core\Exception\NotFoundException (404)]                                               
  {                                                                                                   
    "error": {                                                                                        
      "code": 404,                                                                                    
      "message": "No such object: xxxxx/bundles/storefront/administration/css/",      
      "errors": [                                                                                     
        {                                                                                             
          "message": "No such object: xxxxx/bundles/storefront/administration/css/",  
          "domain": "global",                                                                         
          "reason": "notFound"                                                                        
        }                                                                                             
      ]                                                                                               
    }                                                                                                 
  }                                                                                                   
                                                                                                      

Exception trace:
  at /var/www/html/vendor/google/cloud-core/src/RequestWrapper.php:368
 Google\Cloud\Core\RequestWrapper->convertToGoogleException() at /var/www/html/vendor/google/cloud-core/src/RequestWrapper.php:207
 Google\Cloud\Core\RequestWrapper->send() at /var/www/html/vendor/google/cloud-core/src/RestTrait.php:94
 Google\Cloud\Storage\Connection\Rest->send() at /var/www/html/vendor/google/cloud-storage/src/Connection/Rest.php:167
 Google\Cloud\Storage\Connection\Rest->deleteObject() at /var/www/html/vendor/google/cloud-storage/src/StorageObject.php:185
 Google\Cloud\Storage\StorageObject->delete() at /var/www/html/vendor/superbalist/flysystem-google-storage/src/GoogleStorageAdapter.php:242
 Superbalist\Flysystem\GoogleStorage\GoogleStorageAdapter->delete() at /var/www/html/vendor/superbalist/flysystem-google-storage/src/GoogleStorageAdapter.php:276
 Superbalist\Flysystem\GoogleStorage\GoogleStorageAdapter->deleteDir() at /var/www/html/vendor/league/flysystem/src/Filesystem.php:251
 League\Flysystem\Filesystem->deleteDir() at /var/www/html/vendor/shopware/core/Framework/Plugin/Util/AssetService.php:60
 Shopware\Core\Framework\Plugin\Util\AssetService->copyAssetsFromBundle() at /var/www/html/vendor/shopware/core/Framework/Adapter/Asset/AssetInstallCommand.php:39
 Shopware\Core\Framework\Adapter\Asset\AssetInstallCommand->execute() at /var/www/html/vendor/symfony/console/Command/Command.php:255
 Symfony\Component\Console\Command\Command->run() at /var/www/html/vendor/symfony/console/Application.php:1027
 Symfony\Component\Console\Application->doRunCommand() at /var/www/html/vendor/symfony/framework-bundle/Console/Application.php:97
 Symfony\Bundle\FrameworkBundle\Console\Application->doRunCommand() at /var/www/html/vendor/symfony/console/Application.php:273
 Symfony\Component\Console\Application->doRun() at /var/www/html/vendor/symfony/framework-bundle/Console/Application.php:83
 Symfony\Bundle\FrameworkBundle\Console\Application->doRun() at /var/www/html/vendor/symfony/console/Application.php:149
 Symfony\Component\Console\Application->run() at /var/www/html/bin/console:68
```

### 2. What does this change do, exactly?
Catches the exception `\Google\Cloud\Core\Exception\NotFoundException` so that the function can proceed and copy the asset.

### 3. Describe each step to reproduce the issue or behaviour.
1. Use google storage adapter.
2. Execute `bin/console assets:install -vvv`

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
